### PR TITLE
News Items Styling

### DIFF
--- a/lib/resources/widgets/news_item_widget.dart
+++ b/lib/resources/widgets/news_item_widget.dart
@@ -66,6 +66,16 @@ class _NewsItemState extends State<NewsItem> {
         borderRadius: borderRadius,
         child: Container(
           height: boxHeight,
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: context.color.appBarPrimaryContent.withOpacity(0.3),
+                blurRadius: 30,
+                blurStyle: BlurStyle.inner,
+                offset: Offset(0, 1),
+              ),
+            ],
+          ),
           child: Stack(
             children: [
               Hero(


### PR DESCRIPTION
Fixes #27

Added a nice box shadow on the news item widget container to lift it off the canvas a bit.